### PR TITLE
ITA閣僚修正

### DIFF
--- a/common/characters/ITA.txt
+++ b/common/characters/ITA.txt
@@ -236,7 +236,7 @@ characters={
 				original_tag = ITA
 			}
 			traits = {
-				assault_avaition
+				air_chief_all_weather_2
 			}
 			cost = 100
 			ai_will_do = {


### PR DESCRIPTION
イタリア空軍長官のイタロ・バルボの能力を
作戦整合性－20％からバニラの悪天候ペナルティ－20％に修正しました
陸軍長官はいじっていません