### PR TITLE
勲章粛清

### DIFF
--- a/common/unit_medals/00_default.txt
+++ b/common/unit_medals/00_default.txt
@@ -1,0 +1,31 @@
+# Valid unit modifiers are not exhaustive
+# Currently supported:
+# army_morale
+# army_morale_factor
+# army_org
+# army_org_factor
+# supply_consumption_factor
+# equipment_capture
+# equipment_capture_factor
+# army_fuel_capacity_factor
+# army_fuel_consumption_factor
+# recon_factor
+# recon_factor_while_entrenched
+# transport_capacity (?)
+# breakthrough_factor
+# armor_factor
+# army_strength_factor
+# experience_loss_factor
+# leader_modifier applies unit modifiers to all units under them as a general, similarly to traits.
+# army_attack_factor
+# army_defence_factor
+# max_dig_in
+# max_dig_in_factor
+
+@cost = 10000
+
+unit_medals = {
+	
+
+	
+}


### PR DESCRIPTION
勲章の内容を定義していた、00_default.txt の中の文を削除。
また、念のため勲章授与コストを1万に。
動作確認済みです。