### PR TITLE
火炎放射戦車大隊・レンジャー追加

### DIFF
--- a/common/technologies/infantry.txt
+++ b/common/technologies/infantry.txt
@@ -750,6 +750,7 @@ technologies = {
 
 		enable_subunits = {
 			mountaineers
+			rangers_support
 		}
 
 		on_research_complete_limit = {

--- a/common/units/flame_tank.txt
+++ b/common/units/flame_tank.txt
@@ -10,32 +10,32 @@ sub_units = {
 		type = {
 			armor
 			flame
-			support
+			#support
 		}
 
-		group = support
+		group = mobile #support
 
 		categories = {
 			category_front_line
-			category_support_battalions
+			#category_support_battalions
 			category_tanks
 			category_all_armor
 			category_army
 		}
 
-		combat_width = 0
+		combat_width = 2 #0
 
 		#Size Definitions
-		max_strength = 2
+		max_strength = 3 #2
 		max_organisation = 20
 		default_morale = 0.3
-		manpower = 300
-		training_time = 120
+		manpower = 500 #300
+		training_time = 180 #120
 
 		#Misc Abilities
-		weight = 0.1
-		supply_consumption = 0.02
-		can_be_parachuted = yes
+		weight = 1 #0.1
+		supply_consumption = 0.22 #0.02
+		#can_be_parachuted = yes
 
 		soft_attack = -0.75
 		hard_attack = -0.75
@@ -51,7 +51,7 @@ sub_units = {
 		armor_value = -0.75
 
 		need = {
-			light_tank_flame_chassis = 15
+			light_tank_flame_chassis = 60
 		}
 
 		forest = {
@@ -79,7 +79,7 @@ sub_units = {
 			attack = -0.1
 		}
 
-		same_support_type = flame
+		#same_support_type = flame
 	}
 
 	medium_flame_tank = {
@@ -93,20 +93,20 @@ sub_units = {
 		type = {
 			armor
 			flame
-			support
+			#support
 		}
 
-		group = support
+		group = mobile #support
 
 		categories = {
 			category_front_line
-			category_support_battalions
+			#category_support_battalions
 			category_tanks
 			category_all_armor
 			category_army
 		}
 
-		combat_width = 0
+		combat_width = 2 #0
 		
 		battalion_mult = {
 			category = category_all_infantry
@@ -114,16 +114,16 @@ sub_units = {
 		}
 		
 		#Size Definitions
-		max_strength = 2
+		max_strength = 2.5 #2
 		max_organisation = 20
 		default_morale = 0.3
-		manpower = 300
-		training_time = 120
+		manpower = 500 #300
+		training_time = 180 #120
 
 		#Misc Abilities
-		weight = 0.1
-		supply_consumption = 0.025
-		can_be_parachuted = yes
+		weight = 1.25 #0.1
+		supply_consumption = 1.25 #0.025
+		#can_be_parachuted = yes
 
 		soft_attack = -0.7
 		hard_attack = -0.7
@@ -134,7 +134,7 @@ sub_units = {
 		armor_value = -0.7
 
 		need = {
-			medium_tank_flame_chassis = 15
+			medium_tank_flame_chassis = 50 #15
 		}
 
 		forest = {
@@ -162,7 +162,7 @@ sub_units = {
 			attack = -0.1
 		}
 
-		same_support_type = flame
+		#same_support_type = flame
 	}
 
 	heavy_flame_tank = {
@@ -176,10 +176,10 @@ sub_units = {
 		type = {
 			armor
 			flame
-			support
+			#support
 		}
 
-		group = support
+		group = mobile #support
 		
 		battalion_mult = {
 			category = category_all_infantry
@@ -188,25 +188,25 @@ sub_units = {
 		
 		categories = {
 			category_front_line
-			category_support_battalions
+			#category_support_battalions
 			category_tanks
 			category_all_armor
 			category_army
 		}
 
-		combat_width = 0
+		combat_width = 2 #0
 
 		#Size Definitions
 		max_strength = 2
 		max_organisation = 20
 		default_morale = 0.3
-		manpower = 300
-		training_time = 120
+		manpower = 500
+		training_time = 180 #120
 
 		#Misc Abilities
-		weight = 0.1
-		supply_consumption = 0.03
-		can_be_parachuted = yes
+		weight = 1.5 #0.1
+		supply_consumption = 0.32 #0.03
+		#can_be_parachuted = yes
 
 		soft_attack = -0.625
 		hard_attack = -0.625
@@ -217,7 +217,7 @@ sub_units = {
 		armor_value = -0.625
 
 		need = {
-			heavy_tank_flame_chassis = 15
+			heavy_tank_flame_chassis = 40 #15
 		}
 
 		forest = {
@@ -242,6 +242,6 @@ sub_units = {
 			attack = -0.15
 		}
 
-		same_support_type = flame
+		#same_support_type = flame
 	}
 }

--- a/common/units/recon.txt
+++ b/common/units/recon.txt
@@ -428,78 +428,83 @@ sub_units = {
 	}
 	
 	rangers_support = { #independent recon
-		abbreviation = "RAN"
-		sprite = infantry
-		map_icon_category = infantry
-		priority = 0
-		ai_priority = 0
-		active = no
+	abbreviation = "RAN"
+	sprite = infantry
+	map_icon_category = infantry
+	priority = 0
+	ai_priority = 0
+	active = no
 
-		type = {
-			infantry
-			support
-		}
-		
-		group = support
-		
-		categories = {
-			category_front_line
-			category_support_battalions
-			category_army
-			category_recon
-			category_mountaineers
-		}
-
+	type = {
+		infantry
+		#support
+	}
 	
-		combat_width = 0
+	group = infantry #support
 	
-		#Size Definitions
-		max_strength = 5
-		max_organisation = 30
-		default_morale = 0.3
-		manpower = 500
-		training_time = 120
+	categories = {
+		category_front_line
+		#category_support_battalions
+		category_army
+		#category_recon
+		category_mountaineers
 
-		#Misc Abilities
-		weight = 0.1
-		supply_consumption = 0.06
-		recon = 1
-		can_be_parachuted = yes
+		category_light_infantry
+		category_all_infantry
+		category_special_forces
 
-		# Support nerfs to combat abilities
-		transport = infantry_equipment
-		maximum_speed = 0.6 # move at horsie speeds
-		
-		essential = {
-			infantry_equipment
-			support_equipment
-		}
+	}
 
-		need = {
-			infantry_equipment = 40
-			support_equipment = 15
-		}
-		
-		forest = {
-			movement = 0.15
-			attack = 0.05
-		}
-		hills = {
-			movement = 0.15
-			attack = 0.05
-		}
-		mountain = {
-			movement = 0.10
-			defence = 0.05
-		}
-		jungle = {
-			movement = 0.10
-		}
-		plains = {
-			movement = 0.05
-		}
-		
-		same_support_type = recon # blocks adding other recon types to template
+
+	combat_width = 2
+
+	#Size Definitions
+	max_strength = 20 #5
+	max_organisation = 70 #30
+	default_morale = 0.4 #0/3
+	manpower = 1000 #500
+	training_time = 120
+
+	#Misc Abilities
+	weight = 0.5 #0.1
+	supply_consumption = 0.06
+	#recon = 1
+	can_be_parachuted = yes
+
+	# Support nerfs to combat abilities
+	transport = infantry_equipment
+	maximum_speed = 0.6 # move at horsie speeds
+	
+	essential = {
+		infantry_equipment
+		support_equipment
+	}
+
+	need = {
+		infantry_equipment = 140 #40
+		support_equipment = 15
+	}
+	
+	forest = {
+		movement = 0.15
+		attack = 0.05
+	}
+	hills = {
+		movement = 0.15
+		attack = 0.05
+	}
+	mountain = {
+		movement = 0.10
+		defence = 0.05
+	}
+	jungle = {
+		movement = 0.10
+	}
+	plains = {
+		movement = 0.05
+	}
+	
+	#same_support_type = recon # blocks adding other recon types to template
 	}
 
 	winter_logistics_support = { #Ski Troop Support for Finland. Not really considered recon

--- a/localisation/replace/innova_l_japanese.yml
+++ b/localisation/replace/innova_l_japanese.yml
@@ -54,6 +54,15 @@ ENG_bertram_home_ramsay:0 "バートラム・ラムゼー"
  infantry_at3:0 "歩兵用対戦車装備 III"
  infantry_at3_desc:0 "改良を加えられた新型の歩兵用対戦車装備は、兵士として未熟な者でも容易に取り扱う事ができ、主力級中戦車の正面装甲を破壊する事も可能であるとされている。"
 
+ #火炎放射戦車大隊
+ tank_designer_flame:0 "火炎放射"
+ light_flame_tank:0 "軽火炎放射戦車支援大隊"
+ light_flame_tank_desc:0 "火炎放射器を装備した軽戦車大隊で、都市や要塞への攻撃を支援する。"
+ medium_flame_tank:0 "中火炎放射戦車支援大隊"
+ medium_flame_tank_desc:0 "火炎放射器を装備した中戦車大隊で、都市や要塞への攻撃を支援する。"
+ heavy_flame_tank:0 "重火炎放射戦車支援大隊"
+ heavy_flame_tank_desc:0 "火炎放射器を装備した重戦車大隊で、都市や要塞への攻撃を支援する。"
+
  #tank_modules
  suspension_tech_1:0 "ボギー式サスペンション"
  suspension_tech_1_desc:0 "転輪が個別に取り付けられているため、破損しても簡単に交換が可能な、簡易で安価なサスペンション。"


### PR DESCRIPTION
火炎放射戦車を大隊化。
必要装備数・耐久・物資使用量・人的などは、それぞれ軽・中・重戦車大隊を参考に変更。
中隊のローカライズになっている部分を大隊に変更。

レンジャーを大隊化。
必要装備数・耐久・物資使用量・人的などは、山岳兵を参考に変更。
レンジャーが、一型山岳兵研究で解禁されるように。
大隊カテゴリーを山岳兵を参考に追加。