### PR TITLE
装甲値改修

### DIFF
--- a/common/defines/00_defines.lua
+++ b/common/defines/00_defines.lua
@@ -1048,7 +1048,7 @@ NMilitary = {
 	STRATEGIC_REDEPLOY_ORG_RATIO = 0.1,				-- Ratio of max org while strategic redeployment
 	BATALION_NOT_CHANGED_EXPERIENCE_DROP = 0.0,		-- Division experience drop if unit has same batalion
 	BATALION_CHANGED_EXPERIENCE_DROP = 0.5,			-- Division experience drop if unit has different batalion
-	ARMOR_VS_AVERAGE = 0.3,			                -- how to weight in highest armor & pen vs the division average
+	ARMOR_VS_AVERAGE = 0.0,			                -- how to weight in highest armor & pen vs the division average
 	PEN_VS_AVERAGE = 1.0,
 
 	LAND_EQUIPMENT_BASE_COST = 3,					-- Cost in XP to upgrade a piece of equipment one level is base + ( total levels * ramp )

--- a/common/units/equipment/anti_air.txt
+++ b/common/units/equipment/anti_air.txt
@@ -58,7 +58,7 @@ equipments = {
 		
 		soft_attack = 2
 		hard_attack = 22
-		ap_attack = 35
+		ap_attack = 40
 		air_attack = 50
 
 		build_cost_ic = 2

--- a/common/units/equipment/mechanized.txt
+++ b/common/units/equipment/mechanized.txt
@@ -29,7 +29,7 @@ equipments = {
 		defense = 20
 		breakthrough = 5
 		hardness = 0.70
-		armor_value = 10
+		armor_value = 20
 
 		#Offensive Abilities
 		soft_attack = 2
@@ -73,7 +73,7 @@ equipments = {
 		defense = 25
 		breakthrough = 6.5
 		hardness = 0.75
-		armor_value = 15
+		armor_value = 30
 
 		#Offensive Abilities
 		soft_attack = 3
@@ -102,7 +102,7 @@ equipments = {
 		defense = 30
 		breakthrough = 8
 		hardness = 0.8
-		armor_value = 20
+		armor_value = 40
 
 		#Offensive Abilities
 		soft_attack = 4

--- a/common/units/equipment/tank_chassis.txt
+++ b/common/units/equipment/tank_chassis.txt
@@ -358,7 +358,7 @@ equipments = {
 		build_cost_ic = 3.0
 		maximum_speed = 4.5
 		reliability = 0.55
-		armor_value = 20
+		armor_value = 30
 		resources = {
 			steel = 1
 		}
@@ -454,7 +454,7 @@ equipments = {
 		build_cost_ic = 3.5
 		maximum_speed = 5
 		reliability = 0.65
-		armor_value = 30
+		armor_value = 60
 		resources = {
 			steel = 2
 		}
@@ -771,7 +771,7 @@ equipments = {
 		maximum_speed = 4
 		build_cost_ic = 4.5
 		reliability = 0.5
-		armor_value = 40
+		armor_value = 60
 	}
 
 	medium_tank_chassis_2 = {
@@ -866,7 +866,7 @@ equipments = {
 		maximum_speed = 4
 		build_cost_ic = 5.5
 		reliability = 0.65
-		armor_value = 55
+		armor_value = 80
 		resources = {
 			steel = 1
 		}
@@ -965,7 +965,7 @@ equipments = {
 		maximum_speed = 4.0
 		build_cost_ic = 7.0
 		reliability = 0.75
-		armor_value = 80
+		armor_value = 115
 		resources = {
 			steel = 2
 		}
@@ -1324,7 +1324,7 @@ equipments = {
 		maximum_speed = 0.5
 		build_cost_ic = 6.5
 		reliability = 0.5
-		armor_value = 65
+		armor_value = 80
 		hardness = 0.95
 	}
 
@@ -1420,7 +1420,7 @@ equipments = {
 		maximum_speed = 0.8
 		build_cost_ic = 8.0
 		reliability = 0.6
-		armor_value = 105
+		armor_value = 115
 		resources = {
 			steel = 1
 			chromium = 1
@@ -1520,7 +1520,7 @@ equipments = {
 		maximum_speed = 0.8
 		build_cost_ic = 9.0
 		reliability = 0.65
-		armor_value = 130
+		armor_value = 135
 		resources = {
 			steel = 2
 			chromium = 1
@@ -2305,7 +2305,7 @@ equipments = {
 		build_cost_ic = 2.5
 		maximum_speed = 4.5
 		reliability = 0.55
-		armor_value = 5
+		armor_value = 30
 		hardness = 0.50
 		resources = {
 			steel = 1


### PR DESCRIPTION
変更点

　　車体　　　　　装甲値
2型軽戦車/装甲車　30
3型軽戦車　40
1型中戦車　60　（1型支援AT超え）
2型中戦車/1型重戦車　80
3型中戦車/2型重戦車　115
3型重戦車　130

1型機械化　20　（2型中戦車装甲値/５）
2型機械化　30
3型機械化　40　

2型AA　貫徹値　35→40