### PR TITLE
8/1

### DIFF
--- a/common/ideas/army_spirits.txt
+++ b/common/ideas/army_spirits.txt
@@ -45,13 +45,8 @@ ideas = {
 		}
 		academy_scholarships_spirit = {
 			ledger = army
-			available = { 
-				has_government = communism
-			}
 			modifier = {
-				army_leader_start_level = 1
-				army_leader_cost_factor = -0.3 
-				unit_leader_as_advisor_cp_cost_factor = -0.75
+				army_leader_cost_factor = -0.95
 				custom_modifier_tooltip = academy_scholarships_spirit_tt
 			}
 			ai_will_do = {

--- a/common/ideas/navy_spirits.txt
+++ b/common/ideas/navy_spirits.txt
@@ -77,8 +77,7 @@ ideas = {
 		naval_academy_scholarships_spirit = {
 			ledger = navy
 			modifier = {
-				navy_leader_start_level = 1
-				navy_leader_cost_factor = -0.4
+				navy_leader_cost_factor = -0.95
 				custom_modifier_tooltip = naval_academy_scholarships_spirit_tt
 			}
 			ai_will_do = {


### PR DESCRIPTION
陸海ともに奨学生士官にコストマイナス95パーを付与
レベル1将軍提督が出るように記述を変更
陸のほうはイデオロギー制限があったのでそれを削除