### PR TITLE
2024/8/24

### DIFF
--- a/common/characters/AST.txt
+++ b/common/characters/AST.txt
@@ -438,7 +438,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = AST_sydney_rowell
 			allowed = {
 				original_tag = AST

--- a/common/characters/CHI.txt
+++ b/common/characters/CHI.txt
@@ -579,7 +579,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = CHI_chen_jitang
 			allowed = {
 				original_tag = CHI
@@ -626,7 +626,7 @@ characters={
 			}
 		}
 		advisor={	
-			slot = army_chief
+			slot = high_command
 			idea_token = CHI_he_yingqin
 			allowed = {
 				original_tag = CHI
@@ -830,7 +830,7 @@ characters={
 				original_tag = CHI
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {

--- a/common/characters/ENG.txt
+++ b/common/characters/ENG.txt
@@ -61,7 +61,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = alan_brooke
 			allowed = {
 				original_tag = ENG
@@ -564,7 +564,7 @@ characters={
 				original_tag = ENG
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {

--- a/common/characters/ETH.txt
+++ b/common/characters/ETH.txt
@@ -101,7 +101,7 @@ characters={
 					original_tag = ETH
 				}
 				traits = {
-					army_regrouping_2
+					army_chief_moral_2
 				}
 				cost = 150
 				ai_will_do = {
@@ -361,7 +361,7 @@ characters={
 	}
 	ETH_desta_damtew={
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = ETH_desta_damtew
 			allowed = {
 				original_tag = ETH

--- a/common/characters/FRA.txt
+++ b/common/characters/FRA.txt
@@ -185,7 +185,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = alphonse_georges
 			allowed = {
 				original_tag = FRA
@@ -981,7 +981,7 @@ characters={
 				original_tag = FRA
 			}
 			traits = {
-				army_cavalry_2
+				army_CombinedArms_2
 			}
 			cost = 150
 			ai_will_do = {

--- a/common/characters/GER.txt
+++ b/common/characters/GER.txt
@@ -96,7 +96,7 @@ characters={
 				original_tag = GER
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -1009,7 +1009,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = ludwig_beck
 			allowed = {
 				original_tag = GER
@@ -1081,7 +1081,7 @@ characters={
 			}
 		}
 		advisor={	
-			slot = army_chief
+			slot = high_command
 			idea_token = walther_von_brauchitsch
 			allowed = {
 				original_tag = GER

--- a/common/characters/GRE.txt
+++ b/common/characters/GRE.txt
@@ -170,7 +170,7 @@ characters={
 				}
 			}
 			advisor={
-				slot = army_chief
+				slot = high_command
 				idea_token = GRE_nikolaos_plastiras
 				ledger = army
 				name = GRE_nikolaos_plastiras
@@ -296,7 +296,7 @@ characters={
 					 
 				}
 				traits = {
-					army_regrouping_2
+					army_chief_moral_2
 				}
 				cost = 150
 				ai_will_do = {

--- a/common/characters/HUN.txt
+++ b/common/characters/HUN.txt
@@ -567,7 +567,7 @@ characters={
 				original_tag = HUN
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {

--- a/common/characters/ITA.txt
+++ b/common/characters/ITA.txt
@@ -66,13 +66,13 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = pietro_badoglio
 			allowed = {
 				original_tag = ITA
 			}
 			traits = {
-				army_chief_morale_2
+				army_chief_organizational_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -134,7 +134,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = ugo_cavallero
 			allowed = {
 				original_tag = ITA
@@ -803,7 +803,7 @@ characters={
 				original_tag = ITA
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost =  150
 			ai_will_do = {
@@ -827,7 +827,7 @@ characters={
 				original_tag = ITA
 			}
 			traits = {
-				army_cavalry_1
+				army_CombinedArms_1
 			}
 			cost = 100
 			ai_will_do = {

--- a/common/characters/JAP.txt
+++ b/common/characters/JAP.txt
@@ -1061,7 +1061,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = hideki_tojo
 			allowed = {
 				original_tag = JAP

--- a/common/characters/MAN.txt
+++ b/common/characters/MAN.txt
@@ -312,7 +312,7 @@ characters={
 				original_tag = MAN
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {

--- a/common/characters/MEX.txt
+++ b/common/characters/MEX.txt
@@ -695,7 +695,7 @@ characters={
 				original_tag = MEX
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -724,7 +724,7 @@ characters={
 				
 			}
 			traits = {
-				army_cavalry_3
+				army_CombinedArms_3
 			}
 			cost = 200
 			ai_will_do = {

--- a/common/characters/RAJ.txt
+++ b/common/characters/RAJ.txt
@@ -533,7 +533,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = RAJ_kodandera_cariappa
 			allowed = {
 				original_tag = RAJ

--- a/common/characters/SIA.txt
+++ b/common/characters/SIA.txt
@@ -347,7 +347,7 @@ characters={
 		advisor={
 			
 			
-			slot = army_chief
+			slot = high_command
 			idea_token = SIA_luang_phibunsongkhram
 			allowed = {
 					original_tag = SIA

--- a/common/characters/SOV.txt
+++ b/common/characters/SOV.txt
@@ -140,7 +140,7 @@ characters = {
 				original_tag = SOV
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -1391,7 +1391,7 @@ characters = {
 			}
 		}
 		advisor = {
-			slot = army_chief
+			slot = high_command
 			idea_token = SOV_vasily_blyukher
 			allowed = {
 				original_tag = SOV

--- a/common/characters/SWE.txt
+++ b/common/characters/SWE.txt
@@ -130,7 +130,7 @@ characters={
 	}
 	SWE_ivar_holmquist={
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = SWE_ivar_holmquist
 			allowed = {
 					original_tag = SWE
@@ -269,7 +269,7 @@ characters={
 					original_tag = SWE
 				}
 				traits = {
-					army_entrenchment_3
+					army_chief_entrenchment_3
 				}
 				cost = 200
 				ai_will_do = {
@@ -337,7 +337,7 @@ characters={
 					original_tag = SWE
 				}
 				traits = {
-					army_regrouping_3
+					army_chief_moral_3
 				}
 				cost = 200
 				ai_will_do = {

--- a/common/characters/TUR.txt
+++ b/common/characters/TUR.txt
@@ -295,7 +295,7 @@ characters={
 				has_dlc = "Battle for the Bosporus"
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_organizational_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -774,7 +774,7 @@ characters={
 				has_dlc = "Battle for the Bosporus"
 			}
 			traits = {
-				army_regrouping_2
+				army_chief_moral_2
 			}
 			cost = 150
 			ai_will_do = {
@@ -945,7 +945,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = TUR_fahrettin_altay
 			allowed = {
 				original_tag = TUR

--- a/common/characters/USA.txt
+++ b/common/characters/USA.txt
@@ -236,7 +236,7 @@ characters={
 			}
 		}
 		advisor={
-			slot = army_chief
+			slot = high_command
 			idea_token = douglas_macarthur
 			allowed = {
 				original_tag = USA

--- a/common/country_leader/00_traits.txt
+++ b/common/country_leader/00_traits.txt
@@ -6084,7 +6084,8 @@ leader_traits = {
 			}
 		}
 	}
-
+    
+	#IB_removal
 	army_chief_old_guard = { # Rate at which field experience is gained decreases by 10%
 		sprite = 5 # Should not need sprite, should mostly be secondary
 		experience_gain_army = 0.23
@@ -6154,6 +6155,7 @@ leader_traits = {
 		#experience_gain_army_factor = 0.05
 		experience_gain_army = 0.24
 		experience_gain_factor = 0.5
+		experience_gain_army_unit_factor = 0.50
 
 		
 
@@ -6171,6 +6173,7 @@ leader_traits = {
 		#experience_gain_army_factor = 0.1
 		experience_gain_army = 0.24
 		experience_gain_factor = 0.7
+		experience_gain_army_unit_factor = 0.7
 		
 		
 
@@ -6188,6 +6191,7 @@ leader_traits = {
 		#experience_gain_army_factor = 0.15
 		experience_gain_army = 0.24
 		experience_gain_factor = 0.9
+		experience_gain_army_unit_factor = 0.9
 
 		
 
@@ -6200,11 +6204,10 @@ leader_traits = {
 		}
 	}
 
-
+    #IB_removal
 	army_chief_organizational_1 = { # Ground units get 4 more Organization
 		sprite = 5
 		army_org_factor = 0.04
-		experience_gain_army = 0.24
 
 		
 
@@ -6220,7 +6223,6 @@ leader_traits = {
 	army_chief_organizational_2 = { # Ground units get 8 more Organization
 		sprite = 5
 		army_org_factor = 0.08
-		experience_gain_army = 0.24
 
 		
 
@@ -6236,7 +6238,6 @@ leader_traits = {
 	army_chief_organizational_3 = { # Ground units get 12 more Organization
 		sprite = 5
 		army_org_factor = 0.12
-		experience_gain_army = 0.24
 
 		
 
@@ -6251,7 +6252,8 @@ leader_traits = {
 
 	army_chief_planning_1 = { #
 		sprite = 5
-		planning_speed = 0.05
+		planning_speed = 0.10
+		max_planning = 0.05
 		experience_gain_army = 0.24
 
 		
@@ -6267,7 +6269,8 @@ leader_traits = {
 
 	army_chief_planning_2 = { #
 		sprite = 5
-		planning_speed = 0.10
+		planning_speed = 0.20
+		max_planning = 0.10
 		experience_gain_army = 0.24
 
 		
@@ -6283,7 +6286,8 @@ leader_traits = {
 
 	army_chief_planning_3 = { #
 		sprite = 5
-		planning_speed = 0.15
+		planning_speed = 0.30
+		max_planning = 0.15
 		experience_gain_army = 0.24
 
 		
@@ -6297,10 +6301,10 @@ leader_traits = {
 		}
 	}
 
+    #IB_removal
 	army_chief_morale_1 = { # Ground units get 4 more Morale
 		sprite = 5
 		army_morale_factor = 0.04
-		experience_gain_army = 0.24
 
 		
 
@@ -6316,7 +6320,6 @@ leader_traits = {
 	army_chief_morale_2 = { # Ground units get 8 more Morale
 		sprite = 5
 		army_morale_factor = 0.08
-		experience_gain_army = 0.24
 
 		
 
@@ -6332,7 +6335,6 @@ leader_traits = {
 	army_chief_morale_3 = { # Ground units get 12 more Morale
 		sprite = 5
 		army_morale_factor = 0.12
-		experience_gain_army = 0.24
 
 		
 
@@ -6345,11 +6347,10 @@ leader_traits = {
 		}
 	}
 
-
+    #IB_removal
 	army_chief_maneuver_1 = { # Ground units move 5% faster
 		sprite = 5
 		army_speed_factor = 0.05
-		experience_gain_army = 0.24
 
 		
 
@@ -6365,7 +6366,6 @@ leader_traits = {
 	army_chief_maneuver_2 = { # Ground units move 10% faster
 		sprite = 5
 		army_speed_factor = 0.1
-		experience_gain_army = 0.24
 
 		
 
@@ -6381,7 +6381,6 @@ leader_traits = {
 	army_chief_maneuver_3 = { # Ground units move 15% faster
 		sprite = 5
 		army_speed_factor = 0.15
-		experience_gain_army = 0.24
 
 		
 
@@ -6397,7 +6396,7 @@ leader_traits = {
 	army_chief_entrenchment_1 = {
 		sprite = 5
 		max_dig_in = 3
-		mobilization_speed = -0.02
+		dig_in_speed_factor = 0.1
 		experience_gain_army = 0.24
 
 		
@@ -6414,7 +6413,7 @@ leader_traits = {
 	army_chief_entrenchment_2 = {
 		sprite = 5
 		max_dig_in = 5
-		mobilization_speed = -0.04
+		dig_in_speed_factor = 0.2
 		experience_gain_army = 0.24
 
 		
@@ -6431,7 +6430,7 @@ leader_traits = {
 	army_chief_entrenchment_3 = {
 		sprite = 5
 		max_dig_in = 7
-		mobilization_speed = -0.06
+		dig_in_speed_factor = 0.3
 		experience_gain_army = 0.24
 
 		
@@ -6445,7 +6444,7 @@ leader_traits = {
 		}
 	}
 
-
+    #IB_removal
 	army_entrenchment_1 = { # Ground units entrench n% faster
 		sprite = 9
 		dig_in_speed_factor = 0.08
@@ -6702,7 +6701,7 @@ leader_traits = {
 		}
 	}
 
-
+    #IB_removal
 	army_cavalry_1 = { # +4 cavalry/motorized efficiency
 		sprite = 17
 		cavalry_attack_factor = 0.05
@@ -6760,6 +6759,8 @@ leader_traits = {
 		motorized_defence_factor = 0.05
 		mechanized_attack_factor = 0.05
 		mechanized_defence_factor = 0.05
+		cavalry_attack_factor = 0.05
+		cavalry_defence_factor = 0.05		
 		#experience_gain_army = @experience_gain_low
 
 		
@@ -6779,6 +6780,8 @@ leader_traits = {
 		motorized_defence_factor = 0.1
 		mechanized_attack_factor = 0.1
 		mechanized_defence_factor = 0.1
+		cavalry_attack_factor = 0.1
+		cavalry_defence_factor = 0.1		
 		#experience_gain_army = @experience_gain_medium
 
 		
@@ -6798,6 +6801,8 @@ leader_traits = {
 		motorized_defence_factor = 0.15
 		mechanized_attack_factor = 0.15
 		mechanized_defence_factor = 0.15
+		cavalry_attack_factor = 0.15
+		cavalry_defence_factor = 0.15		
 		#experience_gain_army = @experience_gain_high
 
 		
@@ -6811,7 +6816,7 @@ leader_traits = {
 		}
 	}
 
-
+    #IB_removal
 	army_regrouping_1 = { # Org regenerates 4% faster
 		sprite = 5
 		army_morale_factor = 0.04
@@ -8177,6 +8182,7 @@ leader_traits = {
 	navy_amphibious_assault_1 = {
 		sprite = 3
 		amphibious_invasion = 0.05
+		naval_invasion_capacity = 10
 		#experience_gain_navy = @experience_gain_low
 
 		
@@ -8193,6 +8199,7 @@ leader_traits = {
 	navy_amphibious_assault_2 = {
 		sprite = 3
 		amphibious_invasion = 0.1
+		naval_invasion_capacity = 20
 		#experience_gain_navy = @experience_gain_medium
 
 		
@@ -8209,6 +8216,7 @@ leader_traits = {
 	navy_amphibious_assault_3 = {
 		sprite = 3
 		amphibious_invasion = 0.15
+		naval_invasion_capacity = 30
 		#experience_gain_navy = @experience_gain_high
 
 		

--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -559,6 +559,12 @@ leader_traits = {
 			supply_consumption_factor = -0.15
 		}
 		enable_ability = extra_suplies
+
+		slot = high_command
+		specialist_advisor_trait = army_logistics_1
+		expert_advisor_trait = army_logistics_2
+		genius_advisor_trait = army_logistics_3
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -611,6 +617,7 @@ leader_traits = {
 		specialist_advisor_trait = army_chief_entrenchment_1
 		expert_advisor_trait = army_chief_entrenchment_2
 		genius_advisor_trait = army_chief_entrenchment_3
+
 		ai_will_do = {
 			factor = 1
 		}
@@ -653,11 +660,6 @@ leader_traits = {
 			max_planning = 0.1
 		}
 		
-		slot = army_chief
-		specialist_advisor_trait = army_chief_planning_1
-		expert_advisor_trait = army_chief_planning_2
-		genius_advisor_trait = army_chief_planning_3
-		
 		ai_will_do = {
 			factor = 1
 		}
@@ -686,11 +688,6 @@ leader_traits = {
 
 		custom_effect_tooltip = INCREASED_COUNTERATTACK_CHANCE
 		
-		slot = army_chief
-		specialist_advisor_trait = army_chief_defensive_1
-		expert_advisor_trait = army_chief_defensive_2
-		genius_advisor_trait = army_chief_defensive_3
-		
 		ai_will_do = {
 			factor = 1
 		}
@@ -718,10 +715,10 @@ leader_traits = {
 		custom_effect_tooltip = INCREASED_ASSAULT_AND_SHOCK_CHANCE
 		
 		slot = army_chief
-		specialist_advisor_trait = army_chief_maneuver_1
-		expert_advisor_trait = army_chief_maneuver_2
-		genius_advisor_trait = army_chief_maneuver_3
-		
+		specialist_advisor_trait = army_chief_planning_1
+		expert_advisor_trait = army_chief_planning_2
+		genius_advisor_trait = army_chief_planning_3
+				
 		ai_will_do = {
 			factor = 1
 		}
@@ -742,9 +739,9 @@ leader_traits = {
 		}
 		
 		slot = army_chief
-		specialist_advisor_trait = army_chief_organizational_1
-		expert_advisor_trait = army_chief_organizational_2
-		genius_advisor_trait = army_chief_organizational_3
+		specialist_advisor_trait = army_chief_defensive_1
+		expert_advisor_trait = army_chief_defensive_2
+		genius_advisor_trait = army_chief_defensive_3		
 		
 		ai_will_do = {
 			factor = 1
@@ -763,11 +760,11 @@ leader_traits = {
 		field_marshal_modifier = {
 			army_morale_factor = 0.10
 		}
-		
+
 		slot = army_chief
-		specialist_advisor_trait = army_chief_morale_1
-		expert_advisor_trait = army_chief_morale_2
-		genius_advisor_trait = army_chief_morale_3
+		specialist_advisor_trait = army_chief_drill_1
+		expert_advisor_trait = army_chief_drill_2
+		genius_advisor_trait = army_chief_drill_3		
 		
 		ai_will_do = {
 			factor = 1
@@ -786,11 +783,6 @@ leader_traits = {
 		field_marshal_modifier = {
 			experience_gain_factor = 0.20
 		}
-		
-		slot = army_chief
-		specialist_advisor_trait = army_chief_drill_1
-		expert_advisor_trait = army_chief_drill_2
-		genius_advisor_trait = army_chief_drill_3
 		
 		ai_will_do = {
 			factor = 1
@@ -815,11 +807,11 @@ leader_traits = {
 		modifier = {
 			planning_speed = 0.1
 		}
-		
+
 		slot = high_command
-		specialist_advisor_trait = army_regrouping_1
-		expert_advisor_trait = army_regrouping_2
-		genius_advisor_trait = army_regrouping_3
+		specialist_advisor_trait = army_chief_organizational_1
+		expert_advisor_trait = army_chief_organizational_2
+		genius_advisor_trait = army_chief_organizational_3		
 		
 		ai_will_do = {
 			factor = 1
@@ -873,11 +865,6 @@ leader_traits = {
 			motorized_attack_factor = 0.12
 			mechanized_attack_factor = 0.12
 		}
-		
-		slot = high_command
-		specialist_advisor_trait = army_cavalry_1
-		expert_advisor_trait = army_cavalry_2
-		genius_advisor_trait = army_cavalry_3
 		
 		ai_will_do = {
 			factor = 1
@@ -1005,10 +992,6 @@ leader_traits = {
             }
 		}
 		
-		slot = high_command
-		specialist_advisor_trait = army_entrenchment_1
-		expert_advisor_trait = army_entrenchment_2
-		genius_advisor_trait = army_entrenchment_3
 		
 		ai_will_do = {
 			factor = 1
@@ -1031,6 +1014,11 @@ leader_traits = {
 		modifier = {
 			recon_factor = 0.25
 		}
+
+		slot = high_command
+		specialist_advisor_trait = army_chief_maneuver_1
+		expert_advisor_trait = army_chief_maneuver_2
+		genius_advisor_trait = army_chief_maneuver_3		
 
 		ai_will_do = {
 			factor = 1
@@ -1060,9 +1048,9 @@ leader_traits = {
 		gui_row = 15
 		
 		slot = high_command
-		specialist_advisor_trait = army_logistics_1
-		expert_advisor_trait = army_logistics_2
-		genius_advisor_trait = army_logistics_3
+		specialist_advisor_trait = army_chief_morale_1
+		expert_advisor_trait = army_chief_morale_2
+		genius_advisor_trait = army_chief_morale_3		
 	}
 
 


### PR DESCRIPTION
陸軍長官　　解禁位置　　　　　変更点追加された効果
　陸軍攻撃　攻勢ドクトリン 
　陸軍防御　準備第一主義者 
　陸軍計画　積極的な計画者　　最大立案と立案速度　
　陸軍塹壕　防勢ドクトリン　最大塹壕と塹壕構築速度　
　陸軍改革　迅速な立案者　戦闘による陸軍経験値と将軍経験値増加　
　陸軍訓練　カリスマ

陸軍系軍最高司令部
　XX系部隊
　機甲　戦車指揮官　
　諸兵科　諸兵科連合の達人　
　砲兵　砲弾の運び手
　歩兵　歩兵指揮官　
　特殊部隊　コマンドー　

その他
　陸軍編成　組織者　最高司令部に移動　経験値獲得を削除　
　陸軍士気　優れた参謀　最高司令部に移動　経験値獲得を削除　
　陸軍機動　トリックスター　最高司令部に移動　経験値獲得を削除　
　陸海共同作戦　侵略者　強襲上陸準備期間減少と上陸キャパシティ
　陸軍兵站　兵站の魔術師　
　隠匿　隠匿の達人 


　塹壕陣地　→　削除　＋　隠匿に変更　
　陸軍騎兵　→　削除　＋　諸兵科に変更　
　陸軍再編成　→　削除　＋　陸軍士気に変更　

 変更しなかった効果について
 陸軍兵站　信頼性を全般に改善するバフが見つからなかったので放置
 陸軍訓練　師団訓練速度には練度の上がりやすくなる効果があるので放置